### PR TITLE
Some improvements to messages when players abandon or vote to skip

### DIFF
--- a/content/dota_addons/legion_td/panorama/layout/custom_game/main_hud.xml
+++ b/content/dota_addons/legion_td/panorama/layout/custom_game/main_hud.xml
@@ -46,7 +46,7 @@
         <Panel hittest="false" class="SkipButtonPanel">
           <Button id="SkipButton" onactivate="OnSkipButtonPressed()">
             <Image src="file://{images}/custom_game/skip.psd" /> 
-            <Label id="SkipLabel" class="ButtonLabel" text="#Skip"/>
+            <Label id="SkipLabel" class="ButtonLabel" text="#Ready"/>
           </Button>
         </Panel>
         <Panel hitetst="true" id="ShopPanel">

--- a/game/dota_addons/legion_td/scripts/vscripts/game.lua
+++ b/game/dota_addons/legion_td/scripts/vscripts/game.lua
@@ -827,7 +827,8 @@ function Game:SkipPressed(data)
     local player = Game:FindPlayerWithID(lData.playerID)
     player.wantsSkip = true
     print(lData.playerID .. " wants to skip waiting time.")
-    Say(nil, Game:CountSkipvotes() .. " out of " .. #Game.players .. " want to skip.", false)
+
+    Game:FormatSkipMessage(Game:CountSkipvotes(), Game:CountRemainingPlayers())
     Game:CheckSkip()
 end
 
@@ -841,9 +842,29 @@ function Game:CountSkipvotes()
     return result
 end
 
+function Game:CountRemainingPlayers()
+    local count = 0
+    for _, player in pairs(self.players) do
+        if player:IsActive() then
+            count = count + 1
+        end
+    end
+    return count
+end
+
+function Game:FormatSkipMessage(votes, remaining)
+    local message = ""
+    if votes == 1 then
+        message = votes .. " player is ready for the next round. " .. remaining .. " votes needed."
+    else
+        message = votes .. " players are ready for the next round. " .. remaining .. " votes needed."
+    end
+    GameRules:SendCustomMessage(message, 0, 0)
+end
+
 function Game:CheckSkip()
     for _, player in pairs(self.players) do
-        if not player:WantsToSkip() then
+        if player:IsActive() and not player:WantsToSkip() then
             return
         end
     end

--- a/game/dota_addons/legion_td/scripts/vscripts/player.lua
+++ b/game/dota_addons/legion_td/scripts/vscripts/player.lua
@@ -488,6 +488,6 @@ function Player:Abandon()
 end
 
 function Player:WantsToSkip()
-    if not self:IsActive() then return true end
+    if not self:IsActive() then return false end
     return self.wantsSkip or false
 end

--- a/game/dota_addons/legion_td/scripts/vscripts/player.lua
+++ b/game/dota_addons/legion_td/scripts/vscripts/player.lua
@@ -481,15 +481,9 @@ function Player:Abandon()
         end
     end
     goldEach = math.floor(goldValue / #distributePlayers)
-    GameRules:SendCustomMessage("player abandoned. " .. goldEach .. " gold distributed to each remaining player.", 0, 0)
     PlayerResource:SetGold(self:GetPlayerID(), 0, true)
     PlayerResource:SetGold(self:GetPlayerID(), 0, false)
     self.income = 0
-    print("distributing " .. goldEach .. " abandon gold to " .. #distributePlayers .. " players")
-    for _, player in pairs(distributePlayers) do
-        print("cha-ching")
-        --player.hero:ModifyGold(goldEach, true, DOTA_ModifyGold_Unspecified)
-    end
     self.abandoned = true
 end
 


### PR DESCRIPTION
1. Removed the message that tells players they get leaver gold.
2. Change skip button to say "Ready" in the hope that more players will use it.
3. Change chat message when pressing skip to only count players who are still in the game.