### PR TITLE
Assassin Builder Balance

### DIFF
--- a/game/dota_addons/legion_td/scripts/npc/abilities/assassinbuilder/assassinbuilder_spawn_creeping_shadow.txt
+++ b/game/dota_addons/legion_td/scripts/npc/abilities/assassinbuilder/assassinbuilder_spawn_creeping_shadow.txt
@@ -25,7 +25,7 @@
             "01"
             {
                 "var_type"    "FIELD_INTEGER"
-                "atk_damage_tooltip"    "110"
+                "atk_damage_tooltip"    "130"
             }
 
             "02"
@@ -43,7 +43,7 @@
             "04"
             {
                 "var_type"    "FIELD_INTEGER"
-                "health_tooltip"    "350"
+                "health_tooltip"    "500"
             }
 
             "05"

--- a/game/dota_addons/legion_td/scripts/npc/abilities/assassinbuilder/assassinbuilder_spawn_jester.txt
+++ b/game/dota_addons/legion_td/scripts/npc/abilities/assassinbuilder/assassinbuilder_spawn_jester.txt
@@ -25,7 +25,7 @@
             "01"
             {
                 "var_type"    "FIELD_INTEGER"
-                "atk_damage_tooltip"    "110"
+                "atk_damage_tooltip"    "130"
             }
 
             "02"
@@ -43,13 +43,13 @@
             "04"
             {
                 "var_type"    "FIELD_INTEGER"
-                "health_tooltip"    "320"
+                "health_tooltip"    "400"
             }
 
             "05"
             {
                 "var_type"    "FIELD_INTEGER"
-                "armor_tooltip"    "4"
+                "armor_tooltip"    "5"
             }
 
             "06"

--- a/game/dota_addons/legion_td/scripts/npc/abilities/assassinbuilder/assassinbuilder_spawn_lotus.txt
+++ b/game/dota_addons/legion_td/scripts/npc/abilities/assassinbuilder/assassinbuilder_spawn_lotus.txt
@@ -43,13 +43,13 @@
             "04"
             {
                 "var_type"    "FIELD_INTEGER"
-                "health_tooltip"    "220"
+                "health_tooltip"    "260"
             }
 
             "05"
             {
                 "var_type"    "FIELD_INTEGER"
-                "armor_tooltip"    "3"
+                "armor_tooltip"    "5"
             }
 
             "06"

--- a/game/dota_addons/legion_td/scripts/npc/abilities/assassinbuilder/assassinbuilder_upgrade_blood_drinker.txt
+++ b/game/dota_addons/legion_td/scripts/npc/abilities/assassinbuilder/assassinbuilder_upgrade_blood_drinker.txt
@@ -41,13 +41,13 @@
             "04"
             {
                 "var_type"    "FIELD_INTEGER"
-                "health_tooltip"    "1300"
+                "health_tooltip"    "1450"
             }
 
             "05"
             {
                 "var_type"    "FIELD_INTEGER"
-                "armor_tooltip"    "15"
+                "armor_tooltip"    "17"
             }
 
             "06"

--- a/game/dota_addons/legion_td/scripts/npc/abilities/assassinbuilder/assassinbuilder_upgrade_bloodknife.txt
+++ b/game/dota_addons/legion_td/scripts/npc/abilities/assassinbuilder/assassinbuilder_upgrade_bloodknife.txt
@@ -23,7 +23,7 @@
             "01"
             {
                 "var_type"    "FIELD_INTEGER"
-                "atk_damage_tooltip"    "225"
+                "atk_damage_tooltip"    "265"
             }
 
             "02"
@@ -41,7 +41,7 @@
             "04"
             {
                 "var_type"    "FIELD_INTEGER"
-                "health_tooltip"    "700"
+                "health_tooltip"    "900"
             }
 
             "05"

--- a/game/dota_addons/legion_td/scripts/npc/abilities/assassinbuilder/assassinbuilder_upgrade_dark_wraith.txt
+++ b/game/dota_addons/legion_td/scripts/npc/abilities/assassinbuilder/assassinbuilder_upgrade_dark_wraith.txt
@@ -23,7 +23,7 @@
             "01"
             {
                 "var_type"    "FIELD_INTEGER"
-                "atk_damage_tooltip"    "165"
+                "atk_damage_tooltip"    "185"
             }
 
             "02"
@@ -41,7 +41,7 @@
             "04"
             {
                 "var_type"    "FIELD_INTEGER"
-                "health_tooltip"    "700"
+                "health_tooltip"    "800"
             }
 
             "05"

--- a/game/dota_addons/legion_td/scripts/npc/abilities/assassinbuilder/assassinbuilder_upgrade_mind_breaker.txt
+++ b/game/dota_addons/legion_td/scripts/npc/abilities/assassinbuilder/assassinbuilder_upgrade_mind_breaker.txt
@@ -23,7 +23,7 @@
             "01"
             {
                 "var_type"    "FIELD_INTEGER"
-                "atk_damage_tooltip"    "105"
+                "atk_damage_tooltip"    "125"
             }
 
             "02"
@@ -41,7 +41,7 @@
             "04"
             {
                 "var_type"    "FIELD_INTEGER"
-                "health_tooltip"    "200"
+                "health_tooltip"    "225"
             }
 
             "05"

--- a/game/dota_addons/legion_td/scripts/npc/abilities/assassinbuilder/assassinbuilder_upgrade_nightshade.txt
+++ b/game/dota_addons/legion_td/scripts/npc/abilities/assassinbuilder/assassinbuilder_upgrade_nightshade.txt
@@ -41,13 +41,13 @@
             "04"
             {
                 "var_type"    "FIELD_INTEGER"
-                "health_tooltip"    "400"
+                "health_tooltip"    "450"
             }
 
             "05"
             {
                 "var_type"    "FIELD_INTEGER"
-                "armor_tooltip"    "5"
+                "armor_tooltip"    "7"
             }
 
             "06"

--- a/game/dota_addons/legion_td/scripts/npc/abilities/assassinbuilder/assassinbuilder_upgrade_nimble_edge.txt
+++ b/game/dota_addons/legion_td/scripts/npc/abilities/assassinbuilder/assassinbuilder_upgrade_nimble_edge.txt
@@ -23,7 +23,7 @@
             "01"
             {
                 "var_type"    "FIELD_INTEGER"
-                "atk_damage_tooltip"    "225"
+                "atk_damage_tooltip"    "275"
             }
 
             "02"
@@ -41,7 +41,7 @@
             "04"
             {
                 "var_type"    "FIELD_INTEGER"
-                "health_tooltip"    "700"
+                "health_tooltip"    "850"
             }
 
             "05"

--- a/game/dota_addons/legion_td/scripts/npc/abilities/assassinbuilder/assassinbuilder_upgrade_silent_champion.txt
+++ b/game/dota_addons/legion_td/scripts/npc/abilities/assassinbuilder/assassinbuilder_upgrade_silent_champion.txt
@@ -23,7 +23,7 @@
             "01"
             {
                 "var_type"    "FIELD_INTEGER"
-                "atk_damage_tooltip"    "200"
+                "atk_damage_tooltip"    "210"
             }
 
             "02"
@@ -41,13 +41,13 @@
             "04"
             {
                 "var_type"    "FIELD_INTEGER"
-                "health_tooltip"    "700"
+                "health_tooltip"    "750"
             }
 
             "05"
             {
                 "var_type"    "FIELD_INTEGER"
-                "armor_tooltip"    "6"
+                "armor_tooltip"    "7"
             }
 
             "06"

--- a/game/dota_addons/legion_td/scripts/npc/abilities/assassinbuilder/assassinbuilder_upgrade_stealth_assassin.txt
+++ b/game/dota_addons/legion_td/scripts/npc/abilities/assassinbuilder/assassinbuilder_upgrade_stealth_assassin.txt
@@ -41,13 +41,13 @@
             "04"
             {
                 "var_type"    "FIELD_INTEGER"
-                "health_tooltip"    "1100"
+                "health_tooltip"    "1250"
             }
 
             "05"
             {
                 "var_type"    "FIELD_INTEGER"
-                "armor_tooltip"    "12"
+                "armor_tooltip"    "15"
             }
 
             "06"

--- a/game/dota_addons/legion_td/scripts/npc/abilities/assassinbuilder/assassinbuilder_upgrade_timekeeper.txt
+++ b/game/dota_addons/legion_td/scripts/npc/abilities/assassinbuilder/assassinbuilder_upgrade_timekeeper.txt
@@ -41,13 +41,13 @@
             "04"
             {
                 "var_type"    "FIELD_INTEGER"
-                "health_tooltip"    "650"
+                "health_tooltip"    "750"
             }
 
             "05"
             {
                 "var_type"    "FIELD_INTEGER"
-                "armor_tooltip"    "5"
+                "armor_tooltip"    "7"
             }
 
             "06"

--- a/game/dota_addons/legion_td/scripts/npc/units/assassinbuilder/tower_assassinbuilder_blood_drinker.txt
+++ b/game/dota_addons/legion_td/scripts/npc/units/assassinbuilder/tower_assassinbuilder_blood_drinker.txt
@@ -15,7 +15,7 @@
         "Ability3"                  "ability_empty_3"
         "Ability4"                  "sell"
 
-        "ArmorPhysical"             "15"
+        "ArmorPhysical"             "17"
         "MagicalResistance"         "0"
 
         "AttackCapabilities"        "DOTA_UNIT_CAP_MELEE_ATTACK"
@@ -45,7 +45,7 @@
         "MovementSpeed"             "270"
         "MovementTurnRate"          "0.5"
 
-        "StatusHealth"              "1300"
+        "StatusHealth"              "1450"
         "StatusHealthRegen"         "20"
         "StatusMana"                "0"
         "StatusManaRegen"           "0"

--- a/game/dota_addons/legion_td/scripts/npc/units/assassinbuilder/tower_assassinbuilder_bloodknife.txt
+++ b/game/dota_addons/legion_td/scripts/npc/units/assassinbuilder/tower_assassinbuilder_bloodknife.txt
@@ -20,8 +20,8 @@
 
         "AttackCapabilities"        "DOTA_UNIT_CAP_MELEE_ATTACK"
         "AttackDamageType"          "DAMAGE_TYPE_ArmorPhysical"
-        "AttackDamageMin"           "210"
-        "AttackDamageMax"           "240"
+        "AttackDamageMin"           "250"
+        "AttackDamageMax"           "290"
         "AttackRate"                "0.7"
         "AttackAnimationPoint"      "0.5"
         "AttackAcquisitionRange"    "850"

--- a/game/dota_addons/legion_td/scripts/npc/units/assassinbuilder/tower_assassinbuilder_creeping_shadow.txt
+++ b/game/dota_addons/legion_td/scripts/npc/units/assassinbuilder/tower_assassinbuilder_creeping_shadow.txt
@@ -20,8 +20,8 @@
 
         "AttackCapabilities"        "DOTA_UNIT_CAP_MELEE_ATTACK"
         "AttackDamageType"          "DAMAGE_TYPE_ArmorPhysical"
-        "AttackDamageMin"           "105"
-        "AttackDamageMax"           "115"
+        "AttackDamageMin"           "125"
+        "AttackDamageMax"           "135"
         "AttackRate"                "0.65"
         "AttackAnimationPoint"      "0.5"
         "AttackAcquisitionRange"    "850"
@@ -45,7 +45,7 @@
         "MovementSpeed"             "270"
         "MovementTurnRate"          "0.5"
 
-        "StatusHealth"              "350"
+        "StatusHealth"              "500"
         "StatusHealthRegen"         "3"
         "StatusMana"                "0"
         "StatusManaRegen"           "0"

--- a/game/dota_addons/legion_td/scripts/npc/units/assassinbuilder/tower_assassinbuilder_dark_wraith.txt
+++ b/game/dota_addons/legion_td/scripts/npc/units/assassinbuilder/tower_assassinbuilder_dark_wraith.txt
@@ -20,8 +20,8 @@
 
         "AttackCapabilities"        "DOTA_UNIT_CAP_MELEE_ATTACK"
         "AttackDamageType"          "DAMAGE_TYPE_ArmorPhysical"
-        "AttackDamageMin"           "155"
-        "AttackDamageMax"           "175"
+        "AttackDamageMin"           "175"
+        "AttackDamageMax"           "195"
         "AttackRate"                "0.62"
         "AttackAnimationPoint"      "0.5"
         "AttackAcquisitionRange"    "850"
@@ -45,7 +45,7 @@
         "MovementSpeed"             "270"
         "MovementTurnRate"          "0.5"
 
-        "StatusHealth"              "700"
+        "StatusHealth"              "800"
         "StatusHealthRegen"         "4"
         "StatusMana"                "0"
         "StatusManaRegen"           "0"

--- a/game/dota_addons/legion_td/scripts/npc/units/assassinbuilder/tower_assassinbuilder_jester.txt
+++ b/game/dota_addons/legion_td/scripts/npc/units/assassinbuilder/tower_assassinbuilder_jester.txt
@@ -15,13 +15,13 @@
         "Ability3"                  "ability_empty_3"
         "Ability4"                  "sell"
 
-        "ArmorPhysical"             "4"
+        "ArmorPhysical"             "5"
         "MagicalResistance"         "0"
 
         "AttackCapabilities"        "DOTA_UNIT_CAP_MELEE_ATTACK"
         "AttackDamageType"          "DAMAGE_TYPE_ArmorPhysical"
-        "AttackDamageMin"           "105"
-        "AttackDamageMax"           "115"
+        "AttackDamageMin"           "125"
+        "AttackDamageMax"           "140"
         "AttackRate"                "0.7"
         "AttackAnimationPoint"      "0.5"
         "AttackAcquisitionRange"    "850"
@@ -45,7 +45,7 @@
         "MovementSpeed"             "270"
         "MovementTurnRate"          "0.5"
 
-        "StatusHealth"              "320"
+        "StatusHealth"              "400"
         "StatusHealthRegen"         "20"
         "StatusMana"                "0"
         "StatusManaRegen"           "0"

--- a/game/dota_addons/legion_td/scripts/npc/units/assassinbuilder/tower_assassinbuilder_lotus.txt
+++ b/game/dota_addons/legion_td/scripts/npc/units/assassinbuilder/tower_assassinbuilder_lotus.txt
@@ -15,7 +15,7 @@
         "Ability3"                  "ability_empty_3"
         "Ability4"                  "sell"
 
-        "ArmorPhysical"             "3"
+        "ArmorPhysical"             "5"
         "MagicalResistance"         "0"
 
         "AttackCapabilities"        "DOTA_UNIT_CAP_RANGED_ATTACK"
@@ -45,7 +45,7 @@
         "MovementSpeed"             "270"
         "MovementTurnRate"          "0.5"
 
-        "StatusHealth"              "220"
+        "StatusHealth"              "260"
         "StatusHealthRegen"         "0"
         "StatusMana"                "0"
         "StatusManaRegen"           "0"

--- a/game/dota_addons/legion_td/scripts/npc/units/assassinbuilder/tower_assassinbuilder_mind_breaker.txt
+++ b/game/dota_addons/legion_td/scripts/npc/units/assassinbuilder/tower_assassinbuilder_mind_breaker.txt
@@ -20,8 +20,8 @@
 
         "AttackCapabilities"        "DOTA_UNIT_CAP_RANGED_ATTACK"
         "AttackDamageType"          "DAMAGE_TYPE_ArmorPhysical"
-        "AttackDamageMin"           "100"
-        "AttackDamageMax"           "110"
+        "AttackDamageMin"           "120"
+        "AttackDamageMax"           "130"
         "AttackRate"                "0.5"
         "AttackAnimationPoint"      "0.4"
         "AttackAcquisitionRange"    "850"
@@ -45,7 +45,7 @@
         "MovementSpeed"             "270"
         "MovementTurnRate"          "0.5"
 
-        "StatusHealth"              "200"
+        "StatusHealth"              "225"
         "StatusHealthRegen"         "0"
         "StatusMana"                "100"
         "StatusManaRegen"           "2"

--- a/game/dota_addons/legion_td/scripts/npc/units/assassinbuilder/tower_assassinbuilder_nightshade.txt
+++ b/game/dota_addons/legion_td/scripts/npc/units/assassinbuilder/tower_assassinbuilder_nightshade.txt
@@ -15,7 +15,7 @@
         "Ability3"                  "assassinbuilder_upgrade_timekeeper"
         "Ability4"                  "sell"
 
-        "ArmorPhysical"             "5"
+        "ArmorPhysical"             "7"
         "MagicalResistance"         "0"
 
         "AttackCapabilities"        "DOTA_UNIT_CAP_RANGED_ATTACK"
@@ -45,7 +45,7 @@
         "MovementSpeed"             "270"
         "MovementTurnRate"          "0.5"
 
-        "StatusHealth"              "400"
+        "StatusHealth"              "450"
         "StatusHealthRegen"         "0"
         "StatusMana"                "0"
         "StatusManaRegen"           "0"

--- a/game/dota_addons/legion_td/scripts/npc/units/assassinbuilder/tower_assassinbuilder_nimble_edge.txt
+++ b/game/dota_addons/legion_td/scripts/npc/units/assassinbuilder/tower_assassinbuilder_nimble_edge.txt
@@ -20,8 +20,8 @@
 
         "AttackCapabilities"        "DOTA_UNIT_CAP_MELEE_ATTACK"
         "AttackDamageType"          "DAMAGE_TYPE_ArmorPhysical"
-        "AttackDamageMin"           "200"
-        "AttackDamageMax"           "250"
+        "AttackDamageMin"           "250"
+        "AttackDamageMax"           "300"
         "AttackRate"                "0.7"
         "AttackAnimationPoint"      "0.5"
         "AttackAcquisitionRange"    "850"
@@ -45,7 +45,7 @@
         "MovementSpeed"             "270"
         "MovementTurnRate"          "0.5"
 
-        "StatusHealth"              "700"
+        "StatusHealth"              "850"
         "StatusHealthRegen"         "5"
         "StatusMana"                "0"
         "StatusManaRegen"           "0"

--- a/game/dota_addons/legion_td/scripts/npc/units/assassinbuilder/tower_assassinbuilder_silent_champion.txt
+++ b/game/dota_addons/legion_td/scripts/npc/units/assassinbuilder/tower_assassinbuilder_silent_champion.txt
@@ -15,13 +15,13 @@
         "Ability3"                  "ability_empty_3"
         "Ability4"                  "sell"
 
-        "ArmorPhysical"             "6"
+        "ArmorPhysical"             "7"
         "MagicalResistance"         "0"
 
         "AttackCapabilities"        "DOTA_UNIT_CAP_RANGED_ATTACK"
         "AttackDamageType"          "DAMAGE_TYPE_ArmorPhysical"
-        "AttackDamageMin"           "190"
-        "AttackDamageMax"           "210"
+        "AttackDamageMin"           "200"
+        "AttackDamageMax"           "220"
         "AttackRate"                "0.64"
         "AttackAnimationPoint"      "0.5"
         "AttackAcquisitionRange"    "850"
@@ -45,7 +45,7 @@
         "MovementSpeed"             "270"
         "MovementTurnRate"          "0.5"
 
-        "StatusHealth"              "700"
+        "StatusHealth"              "750"
         "StatusHealthRegen"         "0"
         "StatusMana"                "0"
         "StatusManaRegen"           "0"

--- a/game/dota_addons/legion_td/scripts/npc/units/assassinbuilder/tower_assassinbuilder_stealth_assassin.txt
+++ b/game/dota_addons/legion_td/scripts/npc/units/assassinbuilder/tower_assassinbuilder_stealth_assassin.txt
@@ -15,7 +15,7 @@
         "Ability3"                  "ability_empty_3"
         "Ability4"                  "sell"
 
-        "ArmorPhysical"             "12"
+        "ArmorPhysical"             "15"
         "MagicalResistance"         "0"
 
         "AttackCapabilities"        "DOTA_UNIT_CAP_MELEE_ATTACK"
@@ -45,7 +45,7 @@
         "MovementSpeed"             "270"
         "MovementTurnRate"          "0.5"
 
-        "StatusHealth"              "1100"
+        "StatusHealth"              "1250"
         "StatusHealthRegen"         "10"
         "StatusMana"                "0"
         "StatusManaRegen"           "0"

--- a/game/dota_addons/legion_td/scripts/npc/units/assassinbuilder/tower_assassinbuilder_timekeeper.txt
+++ b/game/dota_addons/legion_td/scripts/npc/units/assassinbuilder/tower_assassinbuilder_timekeeper.txt
@@ -15,7 +15,7 @@
         "Ability3"                  "assassinbuilder_augment_aura"
         "Ability4"                  "sell"
 
-        "ArmorPhysical"             "5"
+        "ArmorPhysical"             "7"
         "MagicalResistance"         "0"
 
         "AttackCapabilities"        "DOTA_UNIT_CAP_RANGED_ATTACK"
@@ -45,7 +45,7 @@
         "MovementSpeed"             "270"
         "MovementTurnRate"          "0.5"
 
-        "StatusHealth"              "650"
+        "StatusHealth"              "750"
         "StatusHealthRegen"         "0"
         "StatusMana"                "0"
         "StatusManaRegen"           "0"


### PR DESCRIPTION
Assassin Builder
---
Mind Breaker:
	Health increased from 200 to 225
	Damage increased from 100-110 to 120-130

Silent Champion:
	Health increased from 700 to 750
	Damage increased from 190-210 to 200-220
	Armor increased from 6 to 7

Creeping Shadow:
	Health increased from 350 to 500
	Damage increased from 105-115 to 125-135

Dark Wraith:
	Health increased from 700 to 800
	Damage increased from 155-175 to 175-195

Nimble Edge:
	Health increased from 700 to 850
	Damage increased from 200-250 to 250-300

Blood Knife:
	Health increased from 700 to 900
	Damage increased from 210-240 to 250-290

Lotus:
	Health increased from 220 to 260
	Armor increased from 3 to 5

Nightshade:
	Health increased from 400 to 450
	Armor increased from 5 to 7

Timekeeper:
	Health increased from 650 to 750
	Armor increased from 5 to 7

Jester:
	Health increased from 320 to 400
	Damage increased from 105-115 to 125-140
	Armor increased from 4 to 5

Stealth Assassin:
	Health increased from 1100 to 1250
	Armor increased from 12 to 15

Blood Drinker:
	Health increased from 1300 to 1450
	Armor increased from 15 to 17
----------------